### PR TITLE
Adding catch case for handling FileNotFound exception when using dll from .NET Core

### DIFF
--- a/NeuralNetwork.NET/cuDNN/CuDnnService.cs
+++ b/NeuralNetwork.NET/cuDNN/CuDnnService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Alea;
@@ -75,10 +76,17 @@ namespace NeuralNetworkNET.cuDNN
                     // Calling this directly could cause a crash in the <Module> loader due to the missing .dll files
                     return CuDnnSupportHelper.IsGpuAccelerationSupported();
                 }
-                catch (TypeInitializationException)
+                catch (Exception e)
                 {
-                    // Missing .dll file
-                    return false;
+                    switch (e)
+                    {
+                        case TypeInitializationException _:
+                        case FileNotFoundException _:
+                            // Missing .dll file
+                            return false;
+                        default:
+                            throw;
+                    }
                 }
             }
         }

--- a/NeuralNetwork.NET/cuDNN/CuDnnService.cs
+++ b/NeuralNetwork.NET/cuDNN/CuDnnService.cs
@@ -76,17 +76,10 @@ namespace NeuralNetworkNET.cuDNN
                     // Calling this directly could cause a crash in the <Module> loader due to the missing .dll files
                     return CuDnnSupportHelper.IsGpuAccelerationSupported();
                 }
-                catch (Exception e)
+                catch (Exception e) when (e is FileNotFoundException || e is TypeInitializationException)
                 {
-                    switch (e)
-                    {
-                        case TypeInitializationException _:
-                        case FileNotFoundException _:
-                            // Missing .dll file
-                            return false;
-                        default:
-                            throw;
-                    }
+                    // Missing .dll file
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
Adding catch for FileNotFound exception to avoid exception in case of execution under .NET Core runtime.

![exception](https://user-images.githubusercontent.com/8339146/68036805-b2807d00-fcc6-11e9-93a0-483d103a2a68.PNG)

Related to issue #90 