### PR TITLE
Added Mish activation function - Ready for merge

### DIFF
--- a/NeuralNetwork.NET/APIs/Enums/ActivationType.cs
+++ b/NeuralNetwork.NET/APIs/Enums/ActivationType.cs
@@ -1,4 +1,4 @@
-﻿namespace NeuralNetworkNET.APIs.Enums
+namespace NeuralNetworkNET.APIs.Enums
 {
     /// <summary>
     /// Indicates an activation function to use in a neural network
@@ -59,6 +59,14 @@
         /// <summary>
         /// A linear activation function that just returns the input value
         /// </summary>
-        Identity
+        Identity,
+
+        /// <summary>
+        /// The Mish function, proposed by Diganta Misra (https://arxiv.org/abs/1908.08681)
+        /// Definition: x tanh(ln(1 + e^2)) 
+        /// Implimentation: x * Tanh(Softplus(x))
+        /// </summary>
+        Mish
+
     }
 }

--- a/NeuralNetwork.NET/Networks/Activations/ActivationFunctionProvider.cs
+++ b/NeuralNetwork.NET/Networks/Activations/ActivationFunctionProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using JetBrains.Annotations;
 using NeuralNetworkNET.APIs.Enums;
 using NeuralNetworkNET.Networks.Activations.Delegates;
@@ -28,7 +28,8 @@ namespace NeuralNetworkNET.Networks.Activations
                 case ActivationType.Softmax: return (ActivationFunctions.Softmax, null);
                 case ActivationType.Softplus: return (ActivationFunctions.Softplus, ActivationFunctions.Sigmoid);
                 case ActivationType.ELU: return (ActivationFunctions.ELU, ActivationFunctions.ELUPrime);
-                case ActivationType.Identity: return (ActivationFunctions.Identity, ActivationFunctions.Identityprime);
+                case ActivationType.Identity: return (ActivationFunctions.Identity, ActivationFunctions.IdentityPrime);
+                case ActivationType.Mish: return (ActivationFunctions.Mish, ActivationFunctions.MishPrime);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(ActivationType), "Unsupported activation function");
             }

--- a/NeuralNetwork.NET/Networks/Activations/ActivationFunctions.cs
+++ b/NeuralNetwork.NET/Networks/Activations/ActivationFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
@@ -217,6 +217,31 @@ namespace NeuralNetworkNET.Networks.Activations
         [PublicAPI]
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Identityprime(float x) => 1;
+        public static float IdentityPrime(float x) => 1;
+
+        /// <summary>
+        /// Applies the Mish function
+        /// </summary>
+        /// <param name="x">The input to process</param>
+        [PublicAPI]
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Mish(float x) => x * Tanh(Softplus(x));
+
+        /// <summary>
+        /// Applies the Mish Derivative function
+        /// </summary>
+        /// <param name="x">The input to process</param>
+        [PublicAPI]
+        [Pure]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float MishPrime(float x)
+        {
+            float
+                omega = (float)Math.Exp(3 * x) + 4 * (float)Math.Exp(2 * x) + (6 + 4 * x) * (float)Math.Exp(x) + 4 * (1 + x),
+                delta = 1 + (float)Math.Pow((Math.Exp(x) + 1), 2),
+                derivative = (float)Math.Exp(x) * omega / (float)Math.Pow(delta, 2);
+            return derivative;
+        }
     }
 }

--- a/NeuralNetwork.NET/Networks/Activations/ActivationFunctions.cs
+++ b/NeuralNetwork.NET/Networks/Activations/ActivationFunctions.cs
@@ -238,10 +238,9 @@ namespace NeuralNetworkNET.Networks.Activations
         public static float MishPrime(float x)
         {
             float
-                omega = (float)Math.Exp(3 * x) + 4 * (float)Math.Exp(2 * x) + (6 + 4 * x) * (float)Math.Exp(x) + 4 * (1 + x),
-                delta = 1 + (float)Math.Pow((Math.Exp(x) + 1), 2),
-                derivative = (float)Math.Exp(x) * omega / (float)Math.Pow(delta, 2);
-            return derivative;
+                s = 2 * (float)Math.Exp(x) + (float)Math.Exp(2 * x) + 2,
+                w = 4 * (x + 1) + (4 * ((float)Math.Exp(2 * x))) + (float)Math.Exp(3 * x) + (float)Math.Exp(x) * (4 * x + 6);
+            return (float)Math.Exp(x) * w / (s * s);
         }
     }
 }


### PR DESCRIPTION
I've added the Mish activatation function as suggested in #93 

~~This is work in progress at the moment as it's working perfectly when not using CUDA.~~

~~When running the DigitsCudaTest sample with the Mish function, I'm currently seeing:~~

     System.Exception: 'methodBody is null
     Source location stack:
    -> at NeuralNetworkNET.Networks.Activations.ActivationFunctions.[Single MishPrime(Single)]
    -> at NeuralNetworkNET.cuDNN.CuDnnExtensions+<>c__DisplayClass1_0.[Void <ActivationBackward>g__Kernel|0(Int32)]
    -> at Alea.Parallel.Device.DeviceFor.[Void Kernel(Int32, Int32, System.Action`1[System.Int32])]
    -> at defining runtime64 (sm52,64bit)

~~MishPrime function looks right to me (and works fine without cuda), but evidently something is wrong. I wonder if this is something Alea need to support.~~

EDIT:
Now working, and ready for merge.
Issue was caused by MishPrime function using Math.Pow (unsupported).